### PR TITLE
Update cinnamon-1.8.8.ebuild

### DIFF
--- a/gnome-extra/cinnamon/cinnamon-1.8.8.ebuild
+++ b/gnome-extra/cinnamon/cinnamon-1.8.8.ebuild
@@ -99,7 +99,7 @@ RDEPEND="${COMMON_DEPEND}
 
 	dev-python/dbus-python[${PYTHON_USEDEP}]
 	dev-python/gconf-python:2
-	dev-python/imaging
+	virtual/python-imaging
 	dev-python/lxml
 
 	x11-themes/gnome-icon-theme-symbolic


### PR DESCRIPTION
replaced hard dependency on dev-python/imaging with virtual/python-imaging