### PR TITLE
media-sound/jamesdsp: fix desktop file

### DIFF
--- a/media-sound/jamesdsp/jamesdsp-9999.ebuild
+++ b/media-sound/jamesdsp/jamesdsp-9999.ebuild
@@ -63,15 +63,7 @@ src_configure() {
 }
 
 src_install() {
-	dobin src/jamesdsp
-	doicon resources/icons/icon.svg
-	make_desktop_entry \
-		"/usr/bin/jamesdsp" \
-		"JamesDSP" \
-		"jamesdsp" \
-		"AudioVideo;Audio;" \
-		"GenericName=Audio effect processor\n\
-		 Keywords=equalizer;audio;effect\n\
-		 StartupNotify=false\n\
-		 Terminal=false\n"
+	dobin "${S}/src/jamesdsp"
+	newicon ${S}/resources/icons/icon.svg jamesdsp.svg
+	make_desktop_entry /usr/bin/jamesdsp JamesDSP /usr/share/pixmaps/jamesdsp.svg "Audio;AudioVideo"
 }


### PR DESCRIPTION
just a simple fix for the .desktop file generation. before this an icon didn't appear.