### PR TITLE
Fix Incorrect Name for Project C Patch

### DIFF
--- a/sys-kernel/cachyos-sources/cachyos-sources-6.1.5.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.1.5.ebuild
@@ -46,7 +46,7 @@ src_prepare() {
 	fi
 
 	if use prjc; then
-		eapply "${FILESDIR}/${KV_MAJOR}.${KV_MINOR}/${KV_MAJOR}.${KV_MINOR}-prjc.patch"
+		eapply "${FILESDIR}/${KV_MAJOR}.${KV_MINOR}/${KV_MAJOR}.${KV_MINOR}-prjc-cachy.patch"
 	fi
 
 	eapply_user


### PR DESCRIPTION
I was trying out the Project C option in Cachy today, but it failed with a build error. After a bit of debugging, it appears the ebuild currently asks to apply a patch named 6.1-prjc.patch, but it appears the file in question is actually called 6.1-prjc-cachy.patch. By adding the -cachy suffix, like in the other scheduler patches, it applies correctly and the install succeeded.