### PR TITLE
Guake 3.10, python dependency repair

### DIFF
--- a/x11-terms/guake/guake-3.10.ebuild
+++ b/x11-terms/guake/guake-3.10.ebuild
@@ -32,7 +32,7 @@ RDEPEND="
 	utempter? ( sys-libs/libutempter )"
 BDEPEND="
 	$(python_gen_cond_dep '
-		dev-python/setuptools_scm[${PYTHON_USEDEP}]
+		dev-python/setuptools-scm[${PYTHON_USEDEP}]
 		test? (
 			dev-python/pyfakefs[${PYTHON_USEDEP}]
 			dev-python/pytest-mock[${PYTHON_USEDEP}]


### PR DESCRIPTION
Changed package name from setuptools_scm (used for python 2.7) to setuptools-scm which is correct for python 3 systems.